### PR TITLE
Use loadArtifact rather than init

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -8,7 +8,7 @@ import { TicTacToe } from './contracts/tictactoe';
 
 import artifact from './contracts/tictactoe.json';
 
-TicTacToe.init(artifact);
+TicTacToe.loadArtifact(artifact);
 
 
 const root = ReactDOM.createRoot(


### PR DESCRIPTION
The example tutorial says using `loadArtifact` and if you use `init` there is a typescript build error